### PR TITLE
Update artifact extraction patterns yaml key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
       "Prefix of dependencies separated by commas, which won't be taken into consideration at
       jmeter-plugins release but are present in github release"
     required: false
-  version-extraction-patterns:
+  artifact-version-extraction-patterns:
     description:
       'Regular expression patterns to extract the version from artifact names for unconventional
       library version patterns'


### PR DESCRIPTION
There was a mismatch between the defined input in action.yaml and what was actually obtained in the backend. 

Now it's standardized to artifact-version-extraction-patterns